### PR TITLE
Исправлена сильная связанность CommandsHandler и OkHttpTelegramClient

### DIFF
--- a/src/main/java/ru/gpbitfactory/minibank/telegrambot/config/TelegramBotConfiguration.java
+++ b/src/main/java/ru/gpbitfactory/minibank/telegrambot/config/TelegramBotConfiguration.java
@@ -5,9 +5,11 @@ import lombok.SneakyThrows;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.telegram.telegrambots.client.okhttp.OkHttpTelegramClient;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
 import org.telegram.telegrambots.longpolling.TelegramBotsLongPollingApplication;
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
 import ru.gpbitfactory.minibank.telegrambot.handler.CommandsHandler;
 
 import java.util.List;
@@ -20,8 +22,13 @@ public class TelegramBotConfiguration {
     private final TelegramBotProperties properties;
 
     @Bean
-    public LongPollingUpdateConsumer longPollingUpdateConsumer(List<BotCommand> commands) {
-        return new CommandsHandler(properties.getToken(), properties.getName(), commands);
+    public TelegramClient telegramClient() {
+        return new OkHttpTelegramClient(properties.getToken());
+    }
+
+    @Bean
+    public LongPollingUpdateConsumer longPollingUpdateConsumer(TelegramClient telegramClient, List<BotCommand> commands) {
+        return new CommandsHandler(telegramClient, properties.isAllowCommandsWithParameters(), properties.getName(), commands);
     }
 
     @Bean

--- a/src/main/java/ru/gpbitfactory/minibank/telegrambot/config/TelegramBotProperties.java
+++ b/src/main/java/ru/gpbitfactory/minibank/telegrambot/config/TelegramBotProperties.java
@@ -11,4 +11,5 @@ public class TelegramBotProperties {
 
     private String name;
     private String token;
+    private boolean allowCommandsWithParameters;
 }

--- a/src/main/java/ru/gpbitfactory/minibank/telegrambot/handler/CommandsHandler.java
+++ b/src/main/java/ru/gpbitfactory/minibank/telegrambot/handler/CommandsHandler.java
@@ -1,18 +1,19 @@
 package ru.gpbitfactory.minibank.telegrambot.handler;
 
 import lombok.SneakyThrows;
-import org.telegram.telegrambots.client.okhttp.OkHttpTelegramClient;
 import org.telegram.telegrambots.extensions.bots.commandbot.CommandLongPollingTelegramBot;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.util.List;
 
 public class CommandsHandler extends CommandLongPollingTelegramBot {
 
-    public CommandsHandler(String botToken, String botName, List<BotCommand> commands) {
-        super(new OkHttpTelegramClient(botToken), true, () -> botName);
+    public CommandsHandler(TelegramClient telegramClient, boolean allowCommandsWithParameters,
+                           String botName, List<BotCommand> commands) {
+        super(telegramClient, allowCommandsWithParameters, () -> botName);
         commands.forEach(this::register);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,4 @@ spring:
 telegram-bot:
   name: ${BOT_NAME}
   token: ${BOT_TOKEN}
+  allow-commands-with-parameters: true


### PR DESCRIPTION
1. Исправлена сильная связанность CommandsHandler и OkHttpTelegramClient
2. Из конструктора CommandsHandler убрано захордкоженое занчение параметра конструктора суперкласса - `allowCommandsWithUsername`